### PR TITLE
Update TcpSocket.php for increasing buffer size

### DIFF
--- a/app/Socket/TcpSocket.php
+++ b/app/Socket/TcpSocket.php
@@ -91,7 +91,7 @@ class TcpSocket extends AbstractSocket{
      * max length for JSON data string
      * -> throw OverflowException on exceed
      */
-    const JSON_DECODE_MAX_LENGTH    = 65536 * 4;
+    const JSON_DECODE_MAX_LENGTH    = 65536 * 6;
 
     /**
      * @see TcpSocket::DEFAULT_ACCEPT_TYPE


### PR DESCRIPTION
The JSON limit value is a bit low for the default 100 systems map.
Arround 70-80 systems depending complexity, it will raise an error and prevent map updating through websocket.

`app/Socket/TcpSocket.php line 364 | connectionError() | debug,error | An error occured on the underlying stream while waiting for event: Buffer size exceeded`

this change will increase it by +50%.

